### PR TITLE
박스 정보들을 이미지 ID에 따라 묶었습니다.

### DIFF
--- a/tfrecord/create_tf_main.py
+++ b/tfrecord/create_tf_main.py
@@ -1,0 +1,26 @@
+import numpy as np
+import tensorflow as tf
+import json
+import os.path as op
+import io
+from PIL import Image
+import tfrecords
+import os
+
+
+
+def convert_to_tfrecords():
+    src_path = "/home/rilab/workspace/cocotry/annotations/"
+    filename_json = "instances_val2017.json"
+    img_path = "/home/rilab/workspace/cocotry/val2017/"
+    Tfmaker = tfrecords.TfrecordMaker(src_path, filename_json, img_path)
+    file_list = os.listdir(img_path)
+    Tfmaker.get_image_annotations()
+    box_annotations = Tfmaker.matching_with_im_box(Tfmaker.im_ids, Tfmaker.get_bbox_annotations())
+    print(box_annotations)
+    print(len(box_annotations))
+
+
+
+
+convert_to_tfrecords()

--- a/tfrecord/tfrecords.py
+++ b/tfrecord/tfrecords.py
@@ -9,9 +9,10 @@ tfrec_name = 'instances_val2017.tfrecords'
 
 
 class TfrecordMaker:
-    def __init__(self, srcpath,filename):
+    def __init__(self, srcpath,filename_json, filename_image):
         self.srcpath = srcpath
-        self.filename = filename
+        self.filename_json = filename_json
+        self.filename_image = filename_image
         self.image = None
         self.category_id = None
         self.category_ids = []
@@ -24,7 +25,7 @@ class TfrecordMaker:
         self.im_hs = []
         self.im_w = None
         self.im_ws = []
-        self.data_file = open(op.join(self.srcpath, self.filename))
+        self.data_file = open(op.join(self.srcpath, self.filename_json))
         self.data = json.load(self.data_file)
         self.annotations_list = self.data['annotations']
         self.image_list = self.data['images']
@@ -37,9 +38,13 @@ class TfrecordMaker:
     def _int64_feature(self, value):
         return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
 
-
     def _float_feature(self, value):
         return tf.train.Feature(float_list=tf.train.FloatList(value=[value]))
+
+    def read_imagebytes(self, filename_image):
+        image = open(filename_image, 'rb')
+        bytes = image.read()
+        return bytes
 
     def create_tf_example(self):
         with tf.io.gfile.GFile(self.srcpath, 'rb') as fid:

--- a/tfrecord/tfrecords.py
+++ b/tfrecord/tfrecords.py
@@ -15,6 +15,10 @@ class TfrecordMaker:
         self.image = None
         self.category_id = None
         self.category_ids = []
+        self.box_x = None
+        self.box_y = None
+        self.box_w = None
+        self.box_h = None
         self.box_total = []
         self.im_h = None
         self.im_hs = []
@@ -32,6 +36,7 @@ class TfrecordMaker:
 
     def _int64_feature(self, value):
         return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
+
 
     def _float_feature(self, value):
         return tf.train.Feature(float_list=tf.train.FloatList(value=[value]))

--- a/tfrecord/tfrecords.py
+++ b/tfrecord/tfrecords.py
@@ -5,15 +5,16 @@ import os.path as op
 import io
 from PIL import Image
 
-tfrec_name = 'instances_val2017.tfrecords'
+
 
 
 class TfrecordMaker:
-    def __init__(self, srcpath,filename_json, filename_image):
+    def __init__(self, srcpath,filename_json, image_path):
         self.srcpath = srcpath
         self.filename_json = filename_json
-        self.filename_image = filename_image
+        self.image_path = image_path
         self.image = None
+        self.image_raw = None
         self.category_id = None
         self.category_ids = []
         self.box_x = None
@@ -21,15 +22,18 @@ class TfrecordMaker:
         self.box_w = None
         self.box_h = None
         self.box_total = []
+        self.box_with_same_id_list = []
         self.im_h = None
         self.im_hs = []
         self.im_w = None
         self.im_ws = []
+        self.im_id = None
+        self.im_ids = []
+        self.im_id_annotations = None
         self.data_file = open(op.join(self.srcpath, self.filename_json))
         self.data = json.load(self.data_file)
         self.annotations_list = self.data['annotations']
         self.image_list = self.data['images']
-        self.feature_dict = {}
 
 
     def _bytes_feature(self, value):
@@ -41,36 +45,41 @@ class TfrecordMaker:
     def _float_feature(self, value):
         return tf.train.Feature(float_list=tf.train.FloatList(value=[value]))
 
-    def read_imagebytes(self, filename_image):
-        image = open(filename_image, 'rb')
-        bytes = image.read()
-        return bytes
+    def open_image(self, filename_image):
+        self.image = np.array(Image.open(filename_image))
+        self.image_raw = self.image.tostring()
 
-    def create_tf_example(self):
-        with tf.io.gfile.GFile(self.srcpath, 'rb') as fid:
-            encoded_jpg = fid.read()
-            encoded_jpg_io = io.BytesIO(encoded_jpg)
-            self.image = Image.open(encoded_jpg_io)
-
+    def get_image_annotations(self):
         for object_images in self.image_list:
             self.im_h = object_images['height']
             self.im_hs.append(self.im_h)
             self.im_w = object_images['width']
             self.im_ws.append(self.im_w)
+            self.im_id = object_images['id']
+            self.im_ids.append(self.im_id)
 
+    def get_bbox_annotations(self):
         for object_annotations in self.annotations_list:
-            [self.box_x, self.box_y, self.box_w, self.box_h] = list(object_annotations['bbox'])
-            self.box_total.append((self.box_x, self.box_y, self.box_w, self.box_h))
-            self.category_id = int(object_annotations['category_id'])
-            self.category_ids.append(self.category_id)
+            self.im_id_annotations = object_annotations['image_id']
+            self.box_x = object_annotations['bbox'][0]
+            self.box_y = object_annotations['bbox'][1]
+            self.box_w = object_annotations['bbox'][2]
+            self.box_h = object_annotations['bbox'][3]
+            box_list = [self.im_id,self.box_y, self.box_x, self.box_h, self.box_w]
+            self.box_total.append(box_list)
+        return self.box_total
 
-        self.feature_dict = {
-            'image height':
-                self._int64_feature(self.im_hs),
-            'image width':
-                self._int64_feature(self.im_ws),
-            'bbox info':
-                self._float_feature(self.box_total),
-            'category id':
-                self._int64_feature(self.category_ids),
-            }
+    def matching_with_im_box(self,im_ids, box_total):
+        same_id_box_list = []
+        for image_id in im_ids:
+            for box_info in box_total:
+                if image_id == box_info[0]:
+                    del box_info[0]
+                    same_id_box_list.append(box_info)
+            box_with_same_id = same_id_box_list
+            self.box_with_same_id_list.append(box_with_same_id)
+            same_id_box_list = []
+        return self.box_with_same_id_list
+
+
+


### PR DESCRIPTION
데이터를 val2017에 대해 테스트했습니다. 이미지 5천장이 있었고, annotations 안의 항목은 36781개였습니다.
이를 annotations 항목 속의 image_id를 확인하여 id가 같은 box끼리 묶었습니다.

get_bbox_annotation() 함수 안에 annotations 항목 속의 image_id를 확인하고, get_image_annotation() 함수 안에 images 항목 속 id를 확인하여 matching_with_im_box() 함수 안에서 둘을 비교해 같은 id에 속하는 box 정보들을 리스트로 묶어 box_with_same_id_list에 저장했습니다.

create_tf_main.py 파일 안에는 우선 제가 하고자 한 작업이 작동을 하는지 테스트를 했습니다. 결과적으로 같은 id에 속하는 박스들의 집합을 모아놓은 리스트의 원소 갯수는 5000개로, 이미지의 수와 일치하여 정상작동하는것을 확인했습니다.

문제는 교수님께서 말씀하신 tfrecord속 고정된 같은 크기의 tensor로 이 박스정보를 넣어야 하는데, 이를 다시 해결해 보겠습니다.