### PR TITLE
스케일별 박스 분배방법을 바꿨습니다.

### DIFF
--- a/tfrecord/tfrecord_reader.py
+++ b/tfrecord/tfrecord_reader.py
@@ -33,9 +33,9 @@ class TfrecordReader:
         decoded["category_m"] = tf.io.decode_raw(parsed["category_m"], tf.float64)
         decoded["category_s"] = tf.io.decode_raw(parsed["category_s"], tf.float64)
         decoded["image"] = tf.reshape(decoded["image"], shape=(cfg.SIZE_H, cfg.SIZE_W, 3))
-        decoded["bbox_l"] = tf.reshape(decoded["bbox_l"], shape=(cfg.SIZE_LBOX, cfg.SIZE_LBOX, 3, 4))
-        decoded["bbox_m"] = tf.reshape(decoded["bbox_m"], shape=(cfg.SIZE_MBOX, cfg.SIZE_MBOX, 3, 4))
-        decoded["bbox_s"] = tf.reshape(decoded["bbox_s"], shape=(cfg.SIZE_SBOX, cfg.SIZE_SBOX, 3, 4))
+        decoded["bbox_l"] = tf.reshape(decoded["bbox_l"], shape=(cfg.MAX_BOX_PER_IMAGE, 4))
+        decoded["bbox_m"] = tf.reshape(decoded["bbox_m"], shape=(cfg.MAX_BOX_PER_IMAGE, 4))
+        decoded["bbox_s"] = tf.reshape(decoded["bbox_s"], shape=(cfg.MAX_BOX_PER_IMAGE, 4))
         # decoded["category"] = tf.reshape(decoded["category"], shape=(cfg.MAX_BOX_PER_IMAGE, ))
         decoded["category_l"] = tf.reshape(decoded["category_l"], shape=(cfg.SIZE_LBOX, cfg.SIZE_LBOX, 3,
                                                                          cfg.NUM_CLASS+1))
@@ -60,9 +60,9 @@ def main():
     dataset = reader.get_dataset()
     print(dataset)
     for i in dataset:
-        lbbox = i["bbox_l"]
         lcate = i["category_l"]
-        print(lbbox.numpy())
+        lbbox = i["bbox_l"]
+        print(lbbox)
 
 
 if __name__ == "__main__":

--- a/utils/data_process_utils.py
+++ b/utils/data_process_utils.py
@@ -3,49 +3,29 @@ import numpy as np
 from setting.config import Config as cfg
 
 def box_scale_processing(grtr):
-    # anchor_rate.shape = (9, 2)
     anchors = np.reshape(cfg.ANCHORS, [9,2])
     anchor_rate = anchors / cfg.SIZE_SQUARE
-    anchors_mask = [[6, 7, 8], [3, 4, 5], [0, 1, 2]]
-
-    lbbox = np.zeros((cfg.SIZE_LBOX, cfg.SIZE_LBOX, 3, 4))
-    mbbox = np.zeros((cfg.SIZE_MBOX, cfg.SIZE_MBOX, 3, 4))
-    sbbox = np.zeros((cfg.SIZE_SBOX, cfg.SIZE_SBOX, 3, 4))
-
-    bbox_real = [sbbox, mbbox, lbbox]
-
+    bbox_scaled = np.zeros((cfg.BATCH_SIZE, 3, cfg.MAX_BOX_PER_IMAGE, 5))
     grtr_wh = grtr[:,2:4]
     grtr_wh_new = grtr_wh[:, tf.newaxis, :]
     # grtr_wh.shape = (NUM_BOX, 1, 2)
-    # calculate : (N, 1, 2) vs (9, 2)
-    # result : (N, 9, 2)
-    # print(grtr_wh_new.shape)
+    # calculate : (NUM_BOX, 1, 2) vs (9, 2)
+    # result : (NUM_BOX, 9, 2)
     mins = np.maximum(-grtr_wh_new / 2, -anchor_rate / 2)
     maxs = np.minimum(grtr_wh_new / 2, anchor_rate / 2)
     inter_wh = maxs-mins
-    # print(grtr_wh_new[:,:,0])
-    # print(grtr_wh_new.shape)
-    # print(inter_wh.shape)
     union_wh = (grtr_wh_new[:,:,0] * grtr_wh_new[:,:,1] + anchor_rate[:,0] * anchor_rate[:,1]
                 - inter_wh[:,:,0] * inter_wh[:,:,1])
     iou = (inter_wh[:,:,0] * inter_wh[:,:,1]) / union_wh
-    # best_box_idx.shape = (NUM_BOX, )
     best_box_idx = tf.argmax(iou, axis=1).numpy()
-    scale = [cfg.SCALE_L, cfg.SCALE_M, cfg.SCALE_S]
-
     for i, idx in enumerate(best_box_idx):
-        # if idx = 0, 1, 2 : small bbox -> group 2
-        # if idx = 3, 4, 5 : medium bbox -> group 1
-        # if idx = 6, 7, 8 : large bbox -> group 0
+        # if idx = 0, 1, 2 : group 2 -> small bbox
+        # if idx = 3, 4, 5 : group 1 -> medium bbox
+        # if idx = 6, 7, 8 : group 0 -> large bbox
         group = 2 - idx // 3
-        grid_x = int(np.floor(grtr[i, 0] / scale[group]))
-        grid_y = int(np.floor(grtr[i, 1] / scale[group]))
-        index_k = anchors_mask[group].index(idx)
-        # print(grtr[i, :2]. shape)
-        # print(bbox_real[group][grid_y, grid_x ,index_k , :2].shape)
-        bbox_real[group][grid_y, grid_x ,index_k , :2] = grtr[i, :2]
-        bbox_real[group][grid_y, grid_x ,index_k , 2:4] = grtr_wh[i]
-
-    return bbox_real
+        bbox_scaled[:, group, i,  :2] = grtr[i, :2]
+        bbox_scaled[:, group, i, 2:4] = grtr_wh[i]
+        bbox_scaled[:, group, i, 4:5] = grtr[i, 4:5]
+    return bbox_scaled
 
 


### PR DESCRIPTION
# 스케일별 박스 분배방법

기존에 박스 사이즈마다 annotation 데이터를 분배할때 다음과 같은 shape을 사용했습니다.
- sbbox -> (52, 52, 3, 4)
- mbbox -> (26, 26, 3, 4)
- lbbox -> (13, 13, 3, 4)

기존의 방식은 iou를 연산할때 텐서 broadcasting이 일어나면 연산량이 너무 많아지기 때문에 다음과 같이 shape을 변경했습니다.
- sbbox -> (NUM_BBOX, 4)
- mbbox -> (NUM_BBOX, 4)
- lbbox -> (NUM_BBOX, 4)

각각은 tfrecord의 데이터 키값에 각각 "bbox_s", "bbox_m", "bbox_l"로 저장하고 사용합니다.